### PR TITLE
Fix: gemspec with a git:// remote.

### DIFF
--- a/typesafe_enum.gemspec
+++ b/typesafe_enum.gemspec
@@ -14,8 +14,7 @@ Gem::Specification.new do |spec|
   spec.description   = 'A gem that implements the typesafe enum pattern in Ruby'
   spec.license       = 'MIT'
 
-  origin_uri = URI(`git config --get remote.origin.url`.chomp)
-  spec.homepage = URI::HTTP.build(host: origin_uri.host, path: origin_uri.path.chomp('.git')).to_s
+  spec.homepage      = 'https://github.com/dmolesUC3/typesafe_enum'
 
   spec.files         = `git ls-files -z`.split("\x0")
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }


### PR DESCRIPTION
If you have a `git` remote, like `git@github.com:dblock/typesafe_enum.git` you get:

```
[!] There was an error parsing `Gemfile`: There was a URI::InvalidURIError while loading typesafe_enum.gemspec: 
bad URI(is not URI?): git@github.com:dblock/typesafe_enum.git from
  /Users/dblock/source/typesafe_enum/dblock/typesafe_enum.gemspec:17:in `block in <main>'
. Bundler cannot continue.

 #  from /Users/dblock/source/typesafe_enum/dblock/Gemfile:3
 #  -------------------------------------------
 #  
 >  gemspec
 #  -------------------------------------------
```