### PR TITLE
No need for instance eval when declaring instance-level methods.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+## Next
+
+- [#3](https://github.com/dmolesUC3/typesafe_enum/pull/3) - No need for `instance_eval` when creating new enum instance methods - [@dblock](https://github.com/dblock).
+
 ## 0.1.2
 
 - Fixed issue where `::find_by_value_str` failed to return `nil` for bad values

--- a/README.md
+++ b/README.md
@@ -189,16 +189,16 @@ Suit.map(&:pip)
 
 ## Enum instances with methods
 
-Enum instances can declare their own methods via `instance_eval`:
+Enum instances can declare their own methods:
 
 ```ruby
 class Operation < TypesafeEnum::Base
-  new(:PLUS, '+').instance_eval do
+  new(:PLUS, '+') do
     def eval(x, y)
       x + y
     end
   end
-  new(:MINUS, '-').instance_eval do
+  new(:MINUS, '-') do
     def eval(x, y)
       x - y
     end
@@ -295,7 +295,7 @@ enum Suit {
 }
 ```
 
-With `TypesafeEnum`, instance-specific methods require extra parentheses and `instance_eval`,
+With `TypesafeEnum`, instance-specific methods require extra parentheses,
 as shown above, and about the best you can do even for simple enums is something like:
 
 ```ruby

--- a/lib/typesafe_enum/base.rb
+++ b/lib/typesafe_enum/base.rb
@@ -126,13 +126,14 @@ module TypesafeEnum
 
     private
 
-    def initialize(key, value = nil)
+    def initialize(key, value = nil, &block)
       fail TypeError, "#{key} is not a symbol" unless key.is_a?(Symbol)
       @key = key
       @value = value || key.to_s.downcase
       @ord = self.class.size
       self.class.class_exec(self) do |instance|
         register(instance)
+        instance.instance_eval(&block) if block_given?
       end
     end
 

--- a/spec/unit/typesafe_enum/base_spec.rb
+++ b/spec/unit/typesafe_enum/base_spec.rb
@@ -337,7 +337,6 @@ module TypesafeEnum
     end
 
     describe '::find_by_ord' do
-
       it 'maps ordinal indices to enum instances' do
         Suit.each do |s|
           expect(Suit.find_by_ord(s.ord)).to be(s)
@@ -376,14 +375,14 @@ module TypesafeEnum
       expect(Suit.map { |s| pip(s) }).to eq(%w(♣ ♦ ♥ ♠))
     end
 
-    it 'supports "inner class" methods via instance_eval' do
+    it 'supports "inner class" methods' do
       class Operation < Base
-        new(:PLUS, '+').instance_eval do
+        new(:PLUS, '+') do
           def eval(x, y)
             x + y
           end
         end
-        new(:MINUS, '-').instance_eval do
+        new(:MINUS, '-') do
           def eval(x, y)
             x - y
           end


### PR DESCRIPTION
Pretty straightforward.